### PR TITLE
add mindspore native graph infer & onnx runtime infer engine

### DIFF
--- a/deploy/MINDIR.md
+++ b/deploy/MINDIR.md
@@ -1,0 +1,29 @@
+# MINDIR部署指南
+
+## 环境要求
+mindspore>=2.1
+
+## 注意事项
+1. 当前仅支持Predict
+2. 理论上也可在Ascend910上运行，未测试
+
+
+## 模型转换
+   ckpt模型转为mindir模型，此步骤可在CPU上运行
+   ```shell
+   python ./deploy/export.py --config ./path_to_config/model.yaml --weight ./path_to_ckpt/weight.ckpt --per_batch_size 1 --file_format MINDIR --device_target CPU
+   e.g.
+   # 在CPU上运行
+   python ./deploy/export.py --config ./configs/yolov5/yolov5n.yaml --weight yolov5n_300e_mAP273-9b16bd7b.ckpt --per_batch_size 1 --file_format MINDIR --device_target CPU
+   ```
+
+## MindIR Test
+   TODO
+   
+## MindIR Predict
+   对单张图片推理：
+   ```shell
+   python ./deploy/predict.py --model_type MindIR --model_path ./path_to_mindir/weight.mindir --config ./path_to_conifg/yolo.yaml --image_path ./path_to_image/image.jpg
+   e.g.
+   python deploy/predict.py --model_type MindIR --model_path ./yolov5n.mindir --config ./configs/yolov5/yolov5n.yaml --image_path ./coco/image/val2017/image.jpg
+   ```

--- a/deploy/ONNX.md
+++ b/deploy/ONNX.md
@@ -1,4 +1,4 @@
-# ONNXRuntime部署指南
+# ONNX部署指南
 
 ## 环境配置
    ```shell
@@ -8,7 +8,8 @@
 
 ## 注意事项
 1. 当前并非所有mindyolo均支持ONNX导出和推理（仅以YoloV3为例）
-2. 导出ONNX需要调整nn.SiLU算子，采用sigmoid算子底层实现  
+2. 当前仅支持Predict功能
+3. 导出ONNX需要调整nn.SiLU算子，采用sigmoid算子底层实现  
 例如：添加如下自定义层并替换mindyolo中所有的nn.SiLU
 ```python
 class EdgeSiLU(nn.Cell):
@@ -32,13 +33,8 @@ class EdgeSiLU(nn.Cell):
    python ./deploy/export.py --config ./configs/yolov3/yolov3.yaml --weight yolov3-darknet53_300e_mAP455-adfb27af.ckpt --per_batch_size 1 --file_format ONNX --device_target CPU
    ```
 
-## ONNXRuntime Test
-   对COCO数据推理：
-   ```shell
-   python ./deploy/test.py --model_type ONNX --model_path ./path_to_onnx_model/model.onnx --config ./path_to_config/yolo.yaml
-   e.g.
-   python ./deploy/test.py --model_type ONNX --model_path ./yolov3.onnx --config ./configs/yolov3/yolov3.yaml
-   ```
+## ONNX Test
+   TODO
    
 ## ONNXRuntime Predict
    对单张图片推理：

--- a/deploy/ONNXRuntime.md
+++ b/deploy/ONNXRuntime.md
@@ -1,0 +1,49 @@
+# ONNXRuntime部署指南
+
+## 环境配置
+   ```shell
+   pip install onnx>=1.9.0
+   pip install onnxruntime>=1.8.0
+   ```
+
+## 注意事项
+1. 当前并非所有mindyolo均支持ONNX导出和推理（仅以YoloV3为例）
+2. 导出ONNX需要调整nn.SiLU算子，采用sigmoid算子底层实现  
+例如：添加如下自定义层并替换mindyolo中所有的nn.SiLU
+```python
+class EdgeSiLU(nn.Cell):
+    """
+    SiLU activation function: x * sigmoid(x). To support for onnx export with nn.SiLU.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def construct(self, x):
+        return x * ops.sigmoid(x)
+```
+
+## 模型转换
+   ckpt模型转为ONNX模型，此步骤以及Test步骤均仅支持CPU上运行
+   ```shell
+   python ./deploy/export.py --config ./path_to_config/model.yaml --weight ./path_to_ckpt/weight.ckpt --per_batch_size 1 --file_format ONNX --device_target [CPU]
+   e.g.
+   # 在CPU上运行
+   python ./deploy/export.py --config ./configs/yolov3/yolov5n.yaml --weight yolov5n_300e_mAP273-9b16bd7b.ckpt --per_batch_size 1 --file_format ONNX --device_target CPU
+   ```
+
+## ONNXRuntime Test
+   对COCO数据推理：
+   ```shell
+   python ./deploy/test.py --model_type ONNX --model_path ./path_to_onnx_model/model.onnx --config ./path_to_config/yolo.yaml
+   e.g.
+   python ./deploy/test.py --model_type ONNX --model_path ./yolov3.onnx --config ./configs/yolov3/yolov3.yaml
+   ```
+   
+## ONNXRuntime Predict
+   对单张图片推理：
+   ```shell
+   python ./deploy/predict.py --model_type ONNX --model_path ./path_to_onnx_model/model.onnx --config ./path_to_config/yolo.yaml --image_path ./path_to_image/image.jpg
+   e.g.
+   python ./deploy/predict.py --model_type ONNX --model_path ./yolov3.onnx --config ./configs/yolov3/yolov3.yaml --image_path ./coco/image/val2017/image.jpg
+   ```

--- a/deploy/ONNXRuntime.md
+++ b/deploy/ONNXRuntime.md
@@ -29,7 +29,7 @@ class EdgeSiLU(nn.Cell):
    python ./deploy/export.py --config ./path_to_config/model.yaml --weight ./path_to_ckpt/weight.ckpt --per_batch_size 1 --file_format ONNX --device_target [CPU]
    e.g.
    # 在CPU上运行
-   python ./deploy/export.py --config ./configs/yolov3/yolov5n.yaml --weight yolov5n_300e_mAP273-9b16bd7b.ckpt --per_batch_size 1 --file_format ONNX --device_target CPU
+   python ./deploy/export.py --config ./configs/yolov3/yolov3.yaml --weight yolov3-darknet53_300e_mAP455-adfb27af.ckpt --per_batch_size 1 --file_format ONNX --device_target CPU
    ```
 
 ## ONNXRuntime Test

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -25,7 +25,7 @@
 ## 快速开始
 
 ### 模型转换
-   ckpt模型转为mindir模型，此步骤可在mindspore-lite CPU/Ascend910上运行，mindspore>=2.1之后也可以直接在mindspore中运行
+   ckpt模型转为mindir模型，此步骤可在CPU/Ascend910上运行
    ```shell
    python ./deploy/export.py --config ./path_to_config/model.yaml --weight ./path_to_ckpt/weight.ckpt --per_batch_size 1 --file_format MINDIR --device_target [CPU/Ascend]
    e.g.
@@ -33,20 +33,6 @@
    python ./deploy/export.py --config ./configs/yolov5/yolov5n.yaml --weight yolov5n_300e_mAP273-9b16bd7b.ckpt --per_batch_size 1 --file_format MINDIR --device_target CPU
    # 在Ascend上运行
    python ./deploy/export.py --config ./configs/yolov5/yolov5n.yaml --weight yolov5n_300e_mAP273-9b16bd7b.ckpt --per_batch_size 1 --file_format MINDIR --device_target Ascend
-   ```
-
-### MindSpore Test
-   ```shell
-   python deploy/test.py --model_type MindIR --model_path ./path_to_mindir/weight.mindir --config ./path_to_config/yolo.yaml
-   e.g.
-   python deploy/test.py --model_type MindIR --model_path ./yolov5n.mindir --config ./configs/yolov5/yolov5n.yaml
-   ```
-
-### MindSpore Predict
-   ```shell
-   python ./deploy/predict.py --model_type MindIR --model_path ./path_to_mindir/weight.mindir --config ./path_to_conifg/yolo.yaml --image_path ./path_to_image/image.jpg
-   e.g.
-   python deploy/predict.py --model_type MindIR --model_path ./yolov5n.mindir --config ./configs/yolov5/yolov5n.yaml --image_path ./coco/image/val2017/image.jpg
    ```
 
 ### Lite Test
@@ -72,9 +58,13 @@
 
 查看 [MINDX](MINDX.md)
 
-## ONNXRuntime部署
+## MindIR部署
+
+查看 [MINDIR](MINDIR.md)
+
+## ONNX部署
 **注意:** 仅部分模型支持导出ONNX并使用ONNXRuntime进行部署  
-查看 [ONNX](ONNXRuntime.md)
+查看 [ONNX](ONNX.md)
 
 
 ## 标准和支持的模型库

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -25,7 +25,7 @@
 ## 快速开始
 
 ### 模型转换
-   ckpt模型转为mindir模型，此步骤可在CPU/Ascend910上运行
+   ckpt模型转为mindir模型，此步骤可在mindspore-lite CPU/Ascend910上运行，mindspore>=2.1之后也可以直接在mindspore中运行
    ```shell
    python ./deploy/export.py --config ./path_to_config/model.yaml --weight ./path_to_ckpt/weight.ckpt --per_batch_size 1 --file_format MINDIR --device_target [CPU/Ascend]
    e.g.
@@ -33,6 +33,20 @@
    python ./deploy/export.py --config ./configs/yolov5/yolov5n.yaml --weight yolov5n_300e_mAP273-9b16bd7b.ckpt --per_batch_size 1 --file_format MINDIR --device_target CPU
    # 在Ascend上运行
    python ./deploy/export.py --config ./configs/yolov5/yolov5n.yaml --weight yolov5n_300e_mAP273-9b16bd7b.ckpt --per_batch_size 1 --file_format MINDIR --device_target Ascend
+   ```
+
+### MindSpore Test
+   ```shell
+   python deploy/test.py --model_type MindIR --model_path ./path_to_mindir/weight.mindir --config ./path_to_config/yolo.yaml
+   e.g.
+   python deploy/test.py --model_type MindIR --model_path ./yolov5n.mindir --config ./configs/yolov5/yolov5n.yaml
+   ```
+
+### MindSpore Predict
+   ```shell
+   python ./deploy/predict.py --model_type MindIR --model_path ./path_to_mindir/weight.mindir --config ./path_to_conifg/yolo.yaml --image_path ./path_to_image/image.jpg
+   e.g.
+   python deploy/predict.py --model_type MindIR --model_path ./yolov5n.mindir --config ./configs/yolov5/yolov5n.yaml --image_path ./coco/image/val2017/image.jpg
    ```
 
 ### Lite Test
@@ -57,6 +71,11 @@
 ## MindX部署
 
 查看 [MINDX](MINDX.md)
+
+## ONNXRuntime部署
+**注意:** 仅部分模型支持导出ONNX并使用ONNXRuntime进行部署  
+查看 [ONNX](ONNXRuntime.md)
+
 
 ## 标准和支持的模型库
 

--- a/deploy/infer_engine/__init__.py
+++ b/deploy/infer_engine/__init__.py
@@ -1,4 +1,6 @@
 from .lite import LiteModel
 from .mindx import MindXModel
+from .mindir import MindIRModel
+from .onnxruntime import ONNXRuntimeModel
 
-__all__ = ["LiteModel", "MindXModel"]
+__all__ = ["LiteModel", "MindXModel", "MindIRModel", "ONNXRuntimeModel"]

--- a/deploy/infer_engine/mindir.py
+++ b/deploy/infer_engine/mindir.py
@@ -1,0 +1,35 @@
+"""MindSpore Graph Mode Inference"""
+
+from .model_base import ModelBase
+import numpy as np
+
+
+class MindIRModel(ModelBase):
+    def __init__(self, model_path):
+        super().__init__()
+        self.model_path = model_path
+        self._init_model()
+
+    def _init_model(self):
+        global ms, nn, Tensor
+        from mindspore import Tensor
+        import mindspore.nn as nn
+        import mindspore as ms
+        ms.set_context(mode=ms.GRAPH_MODE)
+        self.model = nn.GraphCell(ms.load(self.model_path))
+        if not self.model:
+            raise ValueError(f"The model file {self.model_path} load failed.")
+
+    def infer(self, input):
+        inputs = Tensor(input)
+        outputs = self.model(inputs)
+        # extract result from func return into Tensor lists
+        output_list = []
+        for output in outputs:
+            if isinstance(output, tuple):
+                for out in output:
+                    assert not isinstance(out, tuple), 'only support level one tuple'
+                    output_list.append(out.asnumpy())
+            else:
+                output_list.append(output.asnumpy())
+        return output_list

--- a/deploy/infer_engine/onnxruntime.py
+++ b/deploy/infer_engine/onnxruntime.py
@@ -1,0 +1,27 @@
+"""ONNX Runtime Inference"""
+
+from .model_base import ModelBase
+import numpy as np
+
+
+class ONNXRuntimeModel(ModelBase):
+    def __init__(self, model_path):
+        super().__init__()
+        self.model_path = model_path
+        self._init_model()
+
+    def _init_model(self):
+        global ort
+        import onnxruntime as ort
+
+        self.model = ort.InferenceSession(self.model_path, providers=ort.get_available_providers())
+        if not self.model:
+            raise ValueError(f"The model file {self.model_path} load failed.")
+
+    def infer(self, input):
+        assert len(self.model.get_inputs()) == 1, \
+            "Input shape should be 1 but got {}".format(len(self.model.get_inputs()))
+        input_name = self.model.get_inputs()[0].name
+        # extract result from func return into Tensor lists
+        output_list = self.model.run(None, {input_name: input})
+        return output_list

--- a/deploy/predict.py
+++ b/deploy/predict.py
@@ -32,7 +32,7 @@ def get_parser_infer(parents=None):
     parser.add_argument("--img_size", type=int, default=640, help="inference size (pixels)")
     parser.add_argument("--seed", type=int, default=2, help="set global seed")
 
-    parser.add_argument("--model_type", type=str, default="MindX", help="model type MindX/Lite")
+    parser.add_argument("--model_type", type=str, default="MindX", help="model type MindX/Lite/MindIR/ONNX")
     parser.add_argument("--model_path", type=str, default="./models/yolov5s.om", help="model weight path")
 
     parser.add_argument("--save_dir", type=str, default="./runs_infer", help="save dir")
@@ -172,8 +172,14 @@ def infer(args):
     elif args.model_type == "Lite":
         from infer_engine.lite import LiteModel
         network = LiteModel(args.model_path)
+    elif args.model_type == "MindIR":
+        from infer_engine.mindir import MindIRModel
+        network = MindIRModel(args.model_path)
+    elif args.model_type == "ONNX":
+        from infer_engine.onnxruntime import ONNXRuntimeModel
+        network = ONNXRuntimeModel(args.model_path)
     else:
-        raise TypeError("the type only supposed MindX/Lite")
+        raise TypeError("the type only supposed MindX/Lite/MindIR/ONNX")
 
     # Load Image
     if isinstance(args.image_path, str) and os.path.isfile(args.image_path):


### PR DESCRIPTION
Thank you for your contribution to the MindYOLO repo.
Before submitting this PR, please make sure:

- [x] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindyolo/blob/master/CONTRIBUTING.md)
- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [ ] You have added unit tests

## Motivation

add mindspore native graph infer & onnx runtime infer engine  
since after mindspore 2.x, mindspore is able to infer mindIR model in GraphMode without other python pkgs

## Test Plan

--

## Related Issues and PRs

--
