### PR TITLE
make sure lcls is mindspore tensor， to fix issue340

### DIFF
--- a/mindyolo/models/losses/yolov5_loss.py
+++ b/mindyolo/models/losses/yolov5_loss.py
@@ -130,6 +130,8 @@ class YOLOv5Loss(nn.Cell):
         bs = p[0].shape[0]  # batch size
 
         loss = lbox + lobj + lcls
+        # Make sure lcls is mindspore tensor
+        lcls = get_tensor(lcls)
         loss_item = ops.stop_gradient(ops.stack((loss, lbox, lobj, lcls)))
         return loss * bs, loss_item
 


### PR DESCRIPTION
这个PR是为了解决 https://github.com/mindspore-lab/mindyolo/issues/340 这个issue。目前发现，该issue在所有的分支V0.3.0 V0.4.0 master都存在。该解决方案在V0.2.0分支上面做了调试，已通过。请检查是否在其他分支也能够正常使用。