### PR TITLE
fix yolov7's MaxPool2d's bug

### DIFF
--- a/demo/predict.py
+++ b/demo/predict.py
@@ -49,10 +49,17 @@ def get_parser_infer(parents=None):
 
     return parser
 
+def is_yolov7(args):
+    if "yolov7" not in args.config:
+        pass 
+    else:
+        ms.set_context(ascend_config={"precision_mode":"allow_fp32_to_fp16"})
 
 def set_default_infer(args):
     # Set Context
     ms.set_context(mode=args.ms_mode, device_target=args.device_target, max_call_depth=2000)
+    # MaxPool2d does not support dtype=fp32, ops's bug. Needed to be updated when ops's demand is done.
+    is_yolov7(args)
     if args.ms_mode == 0:
         ms.set_context(jit_config={"jit_level": "O2"})
     if args.device_target == "Ascend":

--- a/test.py
+++ b/test.py
@@ -67,10 +67,17 @@ def get_parser_test(parents=None):
     )
     return parser
 
+def is_yolov7(args):
+    if "yolov7" not in args.config:
+        pass 
+    else:
+        ms.set_context(ascend_config={"precision_mode":"allow_fp32_to_fp16"})
 
 def set_default_test(args):
     # Set Context
     ms.set_context(mode=args.ms_mode, device_target=args.device_target, max_call_depth=2000)
+    # MaxPool2d does not support dtype=fp32, ops's bug. Needed to be updated when ops's demand is done.
+    is_yolov7(args)
     if args.ms_mode == 0:
         ms.set_context(jit_config={"jit_level": "O2"})
     if args.device_target == "Ascend":


### PR DESCRIPTION
Thank you for your contribution to the MindYOLO repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindyolo/blob/master/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation
It occured MaxPool2d failed when running test.py or predict.py in 910*.
So need to be circumvented by modifying the script, but this is ops's bug, which only support int and fp16.
This pr needs to be updated when ops's demand is done.

(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
