### PR TITLE
fix difference bewtween high version albumentations

### DIFF
--- a/mindyolo/data/albumentations.py
+++ b/mindyolo/data/albumentations.py
@@ -55,8 +55,8 @@ class Albumentations:
             new = self.transform(image=im, bboxes=bboxes, class_labels=cls)  # transformed
 
             sample['img'] = new['image']
-            sample['bboxes'] = np.array(new['bboxes']).reshape(-1, 1)
-            sample['cls'] = np.array(new['class_labels'])
+            sample['bboxes'] = np.array(new['bboxes'])
+            sample['cls'] = np.array(new['class_labels']).reshape(-1, 1)
             sample['bbox_format'] = "xywhn"
 
         return sample


### PR DESCRIPTION
Thank you for your contribution to the MindYOLO repo.
Before submitting this PR, please make sure:

- [ ] You have read the [Contributing Guidelines on pull requests](https://github.com/mindspore-lab/mindyolo/blob/master/CONTRIBUTING.md)
- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added unit tests

## Motivation
pip install -r requriment.txt, will download high version albumentations. such as 1.4.18, which causes differences of sample['cls'] shape of (n, ). This changes here adjust sample['cls'] shape to (n,1)
(Write your motivation for proposed changes here.)

## Test Plan

(How should this PR be tested? Do you require special setup to run the test or repro the fixed bug?)

## Related Issues and PRs
https://github.com/mindspore-lab/mindyolo/issues/370

(Is this PR part of a group of changes? Link the other relevant PRs and Issues here. Use https://help.github.com/en/articles/closing-issues-using-keywords for help on GitHub syntax)
