### PR TITLE
Fix: Use os.path.basename in mindyolo.utils.utils.draw_result for Windows compatibility

### DIFF
--- a/mindyolo/utils/utils.py
+++ b/mindyolo/utils/utils.py
@@ -144,7 +144,8 @@ def draw_result(img_path, result_dict, data_names, is_coco_dataset=True, save_pa
     from mindyolo.data import COCO80_TO_COCO91_CLASS
 
     os.makedirs(save_path, exist_ok=True)
-    save_result_path = os.path.join(save_path, img_path.split("/")[-1])
+    filename = os.path.basename(img_path)
+    save_result_path = os.path.join(save_path, filename)
     im = cv2.imread(img_path)
     category_id, bbox, score = result_dict["category_id"], result_dict["bbox"], result_dict["score"]
     seg = result_dict.get("segmentation", None)


### PR DESCRIPTION
### Summary

This PR fixes a silent failure bug in the `draw_result` utility function in mindyoly.utils.utils when running on a Windows environment, especially during batch processing. The original code used `img_path.split('/')` to extract the filename, which is not compatible with Windows path separators (`\`), causing `cv2.imwrite` to fail silently.

### The Problem

When the script is run on Windows and processes multiple images from a directory, the `image_path` passed to `draw_result` is a Windows-style path (e.g., `test_images\bus.jpg`). `img_path.split('/')` fails to extract the filename, resulting in an incorrect save path being constructed. `cv2.imwrite` then fails to save the image to this invalid path without raising any exceptions, leading to confusion where logs indicate success but no files are generated.

### The Solution

I have replaced `img_path.split('/')[-1]` with the OS-agnostic `os.path.basename(img_path)`. This ensures that the filename is correctly extracted regardless of the operating system, resolving the issue completely.

### How to Test

1.  On a Windows machine, run the prediction script in batch mode, pointing to a directory of images.
2.  Observe that the result images are now correctly saved in the specified output directory.
